### PR TITLE
MLDS-973 Some affiliates not being displayed

### DIFF
--- a/src/main/java/ca/intelliware/ihtsdo/mlds/domain/Affiliate.java
+++ b/src/main/java/ca/intelliware/ihtsdo/mlds/domain/Affiliate.java
@@ -31,9 +31,9 @@ public class Affiliate extends BaseEntity {
 	@GeneratedValue
 	@Column(name="affiliate_id")
 	Long affiliateId;
-	
+
 	Instant created = Instant.now();
-	
+
 	@JsonIgnore
 	@Column(name="inactive_at")
 	private
@@ -41,12 +41,12 @@ public class Affiliate extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	AffiliateType type;
-	
+
 	String creator;
-	
+
 	@Column(name="import_key")
 	String importKey;
-	
+
 	@OneToMany(cascade=CascadeType.PERSIST, mappedBy="affiliate")
 	Set<CommercialUsage> commercialUsages = Sets.newHashSet();
 
@@ -54,7 +54,7 @@ public class Affiliate extends BaseEntity {
 	@JoinColumn(name="affiliate_details_id")
 	@IndexedEmbedded(prefix="")
 	AffiliateDetails affiliateDetails;
-	
+
 	@JsonIgnoreProperties({"affiliate"})
 	@OneToOne()
 	@JoinColumn(name="application_id")
@@ -74,21 +74,26 @@ public class Affiliate extends BaseEntity {
 	public String getHomeMemberKey() {
 		return homeMember!= null?homeMember.getKey():null;
 	}
-	
+
 	@Column(name="notes_internal")
 	String notesInternal;
 
-	@Fields({
+    @OneToOne()
+    @JoinColumn(name="affiliate_id")
+    @IndexedEmbedded  //(prefix="")
+    ViewAffiliateApplicationCountries approvedCountries;
+
+    @Fields({
 		@Field(name="standingState",bridge=@FieldBridge(impl=StandingStateFieldBridge.class)),
 		@Field(name="ALL",bridge=@FieldBridge(impl=StandingStateFieldBridge.class))
 	})
 	@Enumerated(EnumType.STRING)
 	@Column(name="standing_state")
 	StandingState standingState = StandingState.APPLYING;
-	
+
 	public void addCommercialUsage(CommercialUsage newEntryValue) {
 		Validate.notNull(newEntryValue.getCommercialUsageId());
-		
+
 		if (newEntryValue.affiliate != null) {
 			newEntryValue.affiliate.commercialUsages.remove(newEntryValue);
 		}
@@ -102,7 +107,7 @@ public class Affiliate extends BaseEntity {
 
 	public void addApplication(Application newEntryValue) {
 		Validate.notNull(newEntryValue.getApplicationId());
-		
+
 		if (newEntryValue.affiliate != null) {
 			newEntryValue.affiliate.applications.remove(newEntryValue);
 		}
@@ -115,14 +120,14 @@ public class Affiliate extends BaseEntity {
 	}
 
 	public Affiliate() {
-		
+
 	}
-	
+
 	//For Tests
 	public Affiliate(Long affiliateId) {
 		this.affiliateId = affiliateId;
 	}
-	
+
 	public String getCreator() {
 		return creator;
 	}
@@ -145,7 +150,7 @@ public class Affiliate extends BaseEntity {
 			addApplication(application);
 		}
 	}
-	
+
 	public AffiliateDetails getAffiliateDetails() {
 		return affiliateDetails;
 	}
@@ -157,7 +162,7 @@ public class Affiliate extends BaseEntity {
 	public AffiliateType getType() {
 		return type;
 	}
-	
+
 	public void setType(AffiliateType type) {
 		this.type = type;
 	}

--- a/src/main/java/ca/intelliware/ihtsdo/mlds/domain/ViewAffiliateApplicationCountries.java
+++ b/src/main/java/ca/intelliware/ihtsdo/mlds/domain/ViewAffiliateApplicationCountries.java
@@ -1,0 +1,24 @@
+package ca.intelliware.ihtsdo.mlds.domain;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Fields;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Immutable
+@Table(name = "VW_AFFILIATE_APPROVED_APPLICATION_COUNTRIES")
+public class ViewAffiliateApplicationCountries  {
+
+    @Id
+    @Column(name = "affiliate_id", updatable = false, nullable = false)
+    private Long affiliateId;
+
+    @Fields({ @Field(name="ALL"), @Field()})
+    @Column(name = "countries", updatable = false, nullable = false)
+    private String countries;
+
+}

--- a/src/main/java/ca/intelliware/ihtsdo/mlds/repository/AffiliateSearchRepository.java
+++ b/src/main/java/ca/intelliware/ihtsdo/mlds/repository/AffiliateSearchRepository.java
@@ -67,7 +67,7 @@ public class AffiliateSearchRepository {
 	private Query buildQuery(String q, Member homeMember, StandingState standingState, boolean standingStateNot) {
 		QueryBuilder queryBuilder = getSearchFactory().buildQueryBuilder()
 				.forEntity(Affiliate.class).get();
-		
+
 		//Odd issue with Camel case text not finding exact matches. Workaround using lowercase.
 		Query textQuery = buildWildcardQueryForTokens(queryBuilder, q.toLowerCase());
 
@@ -148,7 +148,7 @@ public class AffiliateSearchRepository {
 					.matching(q)
 					.createQuery();
 			bool.should(affiliateIdQuery);
-			
+
 			// We're letting the default analyzer tokenize the main query for the ALL field
 			Query allKeywordQuery = queryBuilder.keyword()
 					.onField(FIELD_ALL).ignoreFieldBridge().matching(q)
@@ -186,6 +186,10 @@ public class AffiliateSearchRepository {
 					.wildcard()
 					.onField("email").matching(token+"*")
 					.createQuery());
+            bool.should(queryBuilder.keyword()
+                .wildcard()
+                .onField("approvedCountries.countries").matching(token+"*")
+                .createQuery());
 		}
 		Query textQuery = bool.createQuery();
 

--- a/src/main/resources/config/liquibase/changelog/db-changelog-001.xml
+++ b/src/main/resources/config/liquibase/changelog/db-changelog-001.xml
@@ -1576,4 +1576,25 @@ $f$ language plpgsql;
         </addColumn>
     </changeSet>
 
+    <changeSet id="MLDS-973" author="MLR">
+        <preConditions>
+            <tableExists tableName="application"/>
+            <tableExists tableName="member"/>
+            <tableExists tableName="country"/>
+        </preConditions>
+
+        <comment>A view to help out with (text) indexing extra countries related to an affiliate</comment>
+
+        <createView viewName="vw_affiliate_approved_application_countries" >
+                select a.affiliate_id, 
+                       string_agg(common_name, ' ') as countries
+                from application a
+                , member m
+                , country c
+                where approval_state = 'APPROVED'
+                and m.member_id = a.member_id
+                and c.iso_code_2 = m.key
+                group by 1;
+        </createView>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
A view has been added to the database to facilitate MLDS-973, selecting country names for the approved extension application(s) an affiliate has made (if any). These are then included in the Affiliate class through new entity ViewAffiliateApplicationCountries and text indexed. See JIRA ticket for a screenshots doing a search.

