### PR TITLE
Validate SNOMED Version URI before submission

### DIFF
--- a/src/main/webapp/scripts/controllers/AddEditReleaseVersionModalController.js
+++ b/src/main/webapp/scripts/controllers/AddEditReleaseVersionModalController.js
@@ -10,6 +10,33 @@ angular.module('MLDS').controller('AddEditReleaseVersionModalController',
 	$scope.releasePackage = releasePackage;
 	$scope.releaseVersion = releaseVersion;
 	
+	// SNOMED CT version URI
+	var SCT_VERSION_URI_RE = /^http:\/\/snomed\.info\/x?sct\/[0-9]{6,18}\/version\/(19|20)[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$/;
+
+	var ANY_RE = /^.*$/;
+
+	function isOtherPackage() {
+		return $scope.releaseVersion && $scope.releaseVersion.packageType === 'OTHER';
+	};
+
+	// NB: these return shared constants, never freshly-constructed values, so the
+	// ngPattern and interpolation watchers stay reference-stable across digests.
+	$scope.versionUriPattern = function() {
+		return isOtherPackage() ? ABSOLUTE_URI_RE : SCT_VERSION_URI_RE;
+	};
+
+	$scope.versionUriPlaceholder = function() {
+		return isOtherPackage()
+			? 'Enter release version'
+			: 'http://snomed.info/sct/<moduleId>/version/<YYYYMMDD>';
+	};
+
+	$scope.versionUriError = function() {
+		return isOtherPackage()
+			? ''
+			: 'Must be a valid SNOMED CT version URI, e.g. http://snomed.info/sct/32506021000036107/version/20260601 (scheme must be http, not https)';
+	};
+
 	$scope.submitAttempted = false;
 	$scope.submitting = false;
 	$scope.alerts = [];

--- a/src/main/webapp/views/admin/addEditReleaseVersionModal.html
+++ b/src/main/webapp/views/admin/addEditReleaseVersionModal.html
@@ -38,20 +38,27 @@
 
       <div class="form-group">
        <label>Release Version URI</label>
-       <input class="form-control" placeholder="Enter Release Version URI"
-        name="versionURI" ng-model="releaseVersion.versionURI">
+       <input class="form-control" placeholder="{{versionUriPlaceholder()}}"
+        name="versionURI" ng-model="releaseVersion.versionURI"
+        ng-pattern="versionUriPattern()" ng-required="true">
+         <span ng-show="formPackageVersion.versionURI.$error.required && submitAttempted" class="help-block">Required Field</span>
+         <span ng-show="formPackageVersion.versionURI.$error.pattern && submitAttempted" class="help-block">{{versionUriError()}}</span>
       </div>
 
       <div class="form-group">
-              <label>Release Version Dependent URI</label>
-              <input class="form-control" placeholder="Enter Release Version Dependent URI"
-                     name="versionDependentURI" ng-model="releaseVersion.versionDependentURI">
+       <label>Release Version Dependent URI</label>
+       <input class="form-control" placeholder="http://snomed.info/sct/&lt;moduleId&gt;/version/&lt;YYYYMMDD&gt;"
+        name="versionDependentURI" ng-model="releaseVersion.versionDependentURI"
+        ng-pattern="/^http:\/\/snomed\.info\/sct\/[0-9]{6,18}\/version\/(19|20)[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$/">
+         <span ng-show="formPackageVersion.versionDependentURI.$error.pattern && submitAttempted" class="help-block">Must be a SNOMED CT version URI, e.g. http://snomed.info/sct/32506021000036107/version/20260601 (scheme must be http, not https)</span>
       </div>
 
       <div class="form-group">
-              <label>Release Version Dependent Derivative URI</label>
-              <input class="form-control" placeholder="Enter Release Version Dependent Derivative URI"
-                     name="versionDependentDerivativeURI" ng-model="releaseVersion.versionDependentDerivativeURI">
+       <label>Release Version Dependent Derivative URI</label>
+       <input class="form-control" placeholder="http://snomed.info/sct/&lt;moduleId&gt;/version/&lt;YYYYMMDD&gt;"
+        name="versionDependentDerivativeURI" ng-model="releaseVersion.versionDependentDerivativeURI"
+        ng-pattern="/^http:\/\/snomed\.info\/sct\/[0-9]{6,18}\/version\/(19|20)[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$/">
+         <span ng-show="formPackageVersion.versionDependentDerivativeURI.$error.pattern && submitAttempted" class="help-block">Must be a SNOMED CT version URI, e.g. http://snomed.info/sct/32506021000036107/version/20260601 (scheme must be http, not https)</span>
       </div>
           <!--          release package-->
 


### PR DESCRIPTION
To avoid use of https instead of http and other syntax errors, validate and provide guidance in the UI